### PR TITLE
zmiany celu projektu

### DIFF
--- a/Plan Projektu.md
+++ b/Plan Projektu.md
@@ -22,7 +22,7 @@ System e-commerce do zamawiania Pizzy
 Wersja: 0.5 
 26\.10.2024
 #### <a name="_lyvpj0d4owxe"></a>**I. Cel i zakres projektu**
-**Cel projektu:** Przygotowanie dokumentacji i planu teoretycznego systemu do zamawiania pizzy online (strona internetowa/aplikacja mobilna) który umożliwia użytkownikom przeglądanie menu, składanie zamówień, płatności online oraz śledzenie statusu zamówienia. Dokumentacja powinna zawierać opis funkcji, harmonogramu prac oraz zasady zarządzania projektem, aby zminimalizować ryzyko podczas przyszłej realizacji.
+**Cel projektu:** Przygotowanie i wdrożenie systemu zamówień i dostaw online dla przedsiębiorstwa gastronomicznego XYZ, który będzie zapewniał błyskawiczne i ciągłe przyjmowanie zamówień od klientów, rejestrowanie ich w bazie oraz przekazywanie ich pracownikom kuchni, a następnie dostawcom.
 
 **Zakres:** Projekt systemu, przygotowanie architektury oprogramowania oraz makiety. Plan testów funkcjonalnych, dostępności oraz bezpieczeństwa
 


### PR DESCRIPTION
Propozycja zmiany celu projektu na taki, który zmienia sedno z przygotowania dokumentacji na przygotowanie i wdrożenie systemu.

Uzasadnienie:
O ile dobrze rozumiem, to celem zadania nie jest przygotowanie dokumentacji samej w sobie, tylko symulacja planowania, wykonywania i wdrażania systemu.